### PR TITLE
Multiprocessing is now available for TelegramIO

### DIFF
--- a/config/telegram_generic.yml
+++ b/config/telegram_generic.yml
@@ -6,3 +6,7 @@ config:
     - ravestate_conio
     - ravestate_wildtalk
     - ravestate_nlp
+---
+module: telegramio
+config:
+  all_in_one_context: True

--- a/modules/ravestate/context.py
+++ b/modules/ravestate/context.py
@@ -117,6 +117,10 @@ class Context(IContext):
 
         * `arguments`: A series of command line arguments which can be parsed
          by the ravestate command line parser (see argparse.py).
+        * `runtime_overrides`: A list of config overrides in the form of (modulename, key, value).
+         Can be used to set config entries to values other than strings or lists like in command line arguments.
+         An example use-case is a module that starts a new context (in separate process) and can set
+         config entries to Connection Objects to enable communication between old and new context.
         """
         modules, overrides, config_files = argparse.handle_args(*arguments)
         self._config = Configuration(config_files)

--- a/modules/ravestate/context.py
+++ b/modules/ravestate/context.py
@@ -41,6 +41,14 @@ def shutdown(**kwargs) -> Signal:
     return s(":shutdown", **kwargs)
 
 
+def create_and_run_context(*args, runtime_overrides=None):
+    """
+    Creates a new Context with the given parameters and runs it
+    """
+    context = Context(*args, runtime_overrides=runtime_overrides)
+    context.run()
+
+
 class Context(IContext):
     _default_signals: Tuple[Signal] = (startup(), shutdown())
     _default_properties: Tuple[PropertyBase] = (
@@ -65,9 +73,9 @@ class Context(IContext):
         )
     )
 
-    _core_module_name = "core"
-    _import_modules_config = "import"
-    _tick_rate_config = "tickrate"
+    core_module_name = "core"
+    import_modules_config = "import"
+    tick_rate_config = "tickrate"
 
     _lock: RLock
 
@@ -103,7 +111,7 @@ class Context(IContext):
     _run_task: Thread
     _shutdown_flag: Event
 
-    def __init__(self, *arguments):
+    def __init__(self, *arguments, runtime_overrides: List[Tuple[str, str, Any]] = None):
         """
         Construct a context from command line arguments.
 
@@ -113,10 +121,10 @@ class Context(IContext):
         modules, overrides, config_files = argparse.handle_args(*arguments)
         self._config = Configuration(config_files)
         self._core_config = {
-            self._import_modules_config: [],
-            self._tick_rate_config: 20
+            self.import_modules_config: [],
+            self.tick_rate_config: 20
         }
-        self._config.add_conf(Module(name=self._core_module_name, config=self._core_config))
+        self._config.add_conf(Module(name=self.core_module_name, config=self._core_config))
         self._lock = RLock()
         self._shutdown_flag = Event()
         self._properties = dict()
@@ -134,16 +142,21 @@ class Context(IContext):
         for prop in self._default_properties:
             self.add_prop(prop=prop)
 
+        # Load required modules
+        for module_name in self._core_config[self.import_modules_config] + modules:
+            self.add_module(module_name)
+
         # Set required config overrides
         for module_name, key, value in overrides:
             self._config.set(module_name, key, value)
-        if self._core_config[self._tick_rate_config] < 1:
-            logger.error("Attempt to set core config `tickrate` to a value less-than 1!")
-            self._core_config[self._tick_rate_config] = 1
+        # Set additional config runtime overrides
+        if runtime_overrides:
+            for module_name, key, value in runtime_overrides:
+                self._config.set(module_name, key, value)
 
-        # Load required modules
-        for module_name in self._core_config[self._import_modules_config]+modules:
-            self.add_module(module_name)
+        if self._core_config[self.tick_rate_config] < 1:
+            logger.error("Attempt to set core config `tickrate` to a value less-than 1!")
+            self._core_config[self.tick_rate_config] = 1
 
     def emit(self, signal: Signal, parents: Set[Spike]=None, wipe: bool=False, payload: Any=None) -> None:
         """
@@ -478,7 +491,7 @@ class Context(IContext):
 
         **Returns:** An integer tick count.
         """
-        return ceil(seconds * float(self._core_config[self._tick_rate_config]))
+        return ceil(seconds * float(self._core_config[self.tick_rate_config]))
 
     def _add_sig(self, sig: Signal):
         if sig in self._act_per_state_per_signal_age:
@@ -624,7 +637,7 @@ class Context(IContext):
 
     def _run_private(self):
 
-        tick_interval = 1. / self._core_config[self._tick_rate_config]
+        tick_interval = 1. / self._core_config[self.tick_rate_config]
 
         ctx_loop_count = 0
         while not self._shutdown_flag.wait(tick_interval):

--- a/modules/ravestate_ontology/__init__.py
+++ b/modules/ravestate_ontology/__init__.py
@@ -6,6 +6,7 @@ from scientio.ontology.ontology import Ontology
 from scientio.session import Session
 
 from os.path import realpath, dirname, join
+from threading import Event
 
 from ravestate_ontology.dummy_session import DummySession
 
@@ -14,6 +15,7 @@ logger = get_logger(__name__)
 
 onto = None
 sess = None
+initialized: Event = Event()
 NEO4J_ADDRESS_KEY: str = "neo4j_address"
 NEO4J_USERNAME_KEY: str = "neo4j_username"
 NEO4J_PASSWORD_KEY: str = "neo4j_pw"
@@ -34,9 +36,10 @@ with Module(name="ontology", config=CONFIG):
         (the ontology description is a collection of named entity types,
         their properties and relationships)
         then the session is created - it can be accessed with a getter
+        Using ravestate_ontology.initialized.wait() it can be made sure that the session was created before accessing it
         """
         # TODO: Make sess and onto context properties?
-        global onto, sess
+        global onto, sess, initialized
         onto = Ontology(path_to_yaml=join(dirname(realpath(__file__)), "ravestate_ontology.yml"))
         # Create a session (with default Neo4j backend)
         try:
@@ -52,6 +55,7 @@ with Module(name="ontology", config=CONFIG):
                 "\nFor more info on how to set up a server, see https://pypi.org/project/scientio."
                 "\n--------")
             sess = DummySession()
+        initialized.set()
 
 
 def get_session():

--- a/modules/ravestate_telegramio/__init__.py
+++ b/modules/ravestate_telegramio/__init__.py
@@ -1,14 +1,15 @@
 from ravestate.module import Module
 from ravestate_telegramio import telegram_bot
 
-import ravestate_rawio
-
 
 CONFIG = {
-    telegram_bot.TOKEN_CONFIG_KEY: ""
+    telegram_bot.TOKEN_CONFIG_KEY: "",
+    telegram_bot.CHILD_CONN_CONFIG_KEY: None,
+    telegram_bot.CHILD_FILES_CONFIG_KEY: [],
+    telegram_bot.ALL_IN_ONE_CONTEXT_CONFIG_KEY: False
 }
 
-with Module(name="telegramio", config=CONFIG) as mod:
+with Module(name=telegram_bot.MODULE_NAME, config=CONFIG) as mod:
 
     mod.add(telegram_bot.telegram_run)
     mod.add(telegram_bot.telegram_output)

--- a/modules/ravestate_telegramio/__init__.py
+++ b/modules/ravestate_telegramio/__init__.py
@@ -3,10 +3,17 @@ from ravestate_telegramio import telegram_bot
 
 
 CONFIG = {
+    # Token for the Telegram Bot
     telegram_bot.TOKEN_CONFIG_KEY: "",
+    # Not to be set in a config file or via the command line. Will be set by master process as a runtime_override.
     telegram_bot.CHILD_CONN_CONFIG_KEY: None,
+    # The config-paths listed here will be used for each new telegram chat (if they don't share the same context).
+    # Currently only absolute paths are supported
     telegram_bot.CHILD_FILES_CONFIG_KEY: [],
-    telegram_bot.ALL_IN_ONE_CONTEXT_CONFIG_KEY: False
+    # Whether all telegram chats should share the same context or not
+    telegram_bot.ALL_IN_ONE_CONTEXT_CONFIG_KEY: False,
+    # The timespan in minutes in which a chat will be kept active after the last message
+    telegram_bot.CHAT_LIFETIME: 5
 }
 
 with Module(name=telegram_bot.MODULE_NAME, config=CONFIG) as mod:

--- a/modules/ravestate_telegramio/telegram_bot.py
+++ b/modules/ravestate_telegramio/telegram_bot.py
@@ -34,7 +34,7 @@ CHILD_FILES_CONFIG_KEY: str = "child_config_files"
 ALL_IN_ONE_CONTEXT_CONFIG_KEY: str = 'all_in_one_context'
 
 # contains only keys if all chats run in one process, else maps chat_id to Pipe
-active_chats: Dict[int, Union[mp.connection.Connection, None]] = dict()
+active_chats: Dict[int, Optional[mp.connection.Connection]] = dict()
 active_users: Set[int] = set()
 
 

--- a/modules/ravestate_telegramio/telegram_bot.py
+++ b/modules/ravestate_telegramio/telegram_bot.py
@@ -1,8 +1,13 @@
-from typing import Set
+import os
+import multiprocessing as mp
+from multiprocessing.connection import Connection
+import time
+from typing import Set, Dict, Union
 from tempfile import mkstemp
 import requests
 
 from ravestate.constraint import s
+from ravestate.context import Context, create_and_run_context
 from ravestate.property import PropertyBase
 from ravestate.receptor import receptor
 from ravestate.state import state, Delete
@@ -22,9 +27,14 @@ import ravestate_interloc
 import ravestate_ontology
 
 
+MODULE_NAME: str = 'telegramio'
 TOKEN_CONFIG_KEY: str = "telegram-token"
+CHILD_CONN_CONFIG_KEY: str = "child_conn"
+CHILD_FILES_CONFIG_KEY: str = "child_config_files"
+ALL_IN_ONE_CONTEXT_CONFIG_KEY: str = 'all_in_one_context'
 
-active_chats: Set[int] = set()
+# contains only keys if all chats run in one process, else maps chat_id to Pipe
+active_chats: Dict[int, Union[mp.connection.Connection, None]] = dict()
 active_users: Set[int] = set()
 
 
@@ -57,10 +67,21 @@ def telegram_run(ctx: ContextWrapper):
             logger.debug(f"Pushed {telegram_node} to interloc:all")
 
     def make_sure_effective_user_exists(update: Update):
+        """
+        Retrieves scientio Node of User if it exists, otherwise creates it in the scientio session
+        Calls the push_telegram_interloc receptor to push the scientio node into interloc:all
+        Adds the User to the set of active_users
+        """
         if update.effective_user not in active_users:
             # set up scientio
             sess: Session = ravestate_ontology.get_session()
             onto: Ontology = ravestate_ontology.get_ontology()
+
+            tick_interval = 1. / ctx.conf(mod=Context.core_module_name, key=Context.tick_rate_config)
+            while not sess or not onto:
+                time.sleep(tick_interval)
+                sess: Session = ravestate_ontology.get_session()
+                onto: Ontology = ravestate_ontology.get_ontology()
 
             # create scientio Node of type TelegramPerson
             query = Node(metatype=onto.get_type("TelegramPerson"))
@@ -86,23 +107,20 @@ def telegram_run(ctx: ContextWrapper):
             push_telegram_interloc(telegram_node, update.effective_chat.id)
             active_users.add(update.effective_user)
 
-    def handle_text_input(bot: Bot, update: Update):
+    def handle_text(bot: Bot, update: Update):
         """
-        Handler for incoming messages
-        Adds the chat/user of the incoming message to the set of active_chats/active_users
-        Calls the telegram_callback receptor to process the incoming message
-        Retrieves scientio Node of User if it exists, otherwise creates it in the scientio session
-        Calls the push_telegram_interloc receptor to push the scientio node into interloc:all
+        Handle incoming text messages
         """
-        text_receptor(update.effective_message.text)
-        active_chats.add(update.effective_chat.id)
         make_sure_effective_user_exists(update)
+        active_chats[update.effective_chat.id] = None
+        text_receptor(update.effective_message.text)
 
     def handle_photo(bot: Bot, update: Update):
         """
-        Handler for photo messages.
+        Handle incoming photo messages.
         """
         make_sure_effective_user_exists(update)
+        active_chats[update.effective_chat.id] = None
         photo_index = 2  # Seems like a good size index. TODO: Make configurable
         while photo_index >= len(update.effective_message.photo):
             photo_index -= 1
@@ -116,42 +134,125 @@ def telegram_run(ctx: ContextWrapper):
             file.write(photo.content)
         photo_receptor(file_path)
 
+    def handle_input_multiprocess(bot: Bot, update: Update):
+        """
+        Handle incoming messages
+        """
+        if update.effective_chat.id not in active_chats:
+            add_new_child_process(update.effective_chat.id)
+        # write (bot, update) to Pipe
+        active_chats[update.effective_chat.id].send((bot, update))
+
+    def add_new_child_process(chat_id):
+        """
+        Adds the chat of the incoming message to the set of active_chats
+        Creates new Ravestate Context in new Process for the new chat and
+        sets up a bidirectional Pipe for communication between Master and Child Processes
+        """
+        # start method has to be 'spawn'
+        mp_context = mp.get_context('spawn')
+        # Pipe to communicate between Master Process and all children
+        parent_conn, child_conn = mp.Pipe()
+        # create commandline args for child config file
+        args = []
+        for child_config_path in child_config_paths_list:
+            args += ['-f', child_config_path]
+        # set up new Process and override child_conn with the Pipe-Connection
+        p = mp_context.Process(target=create_and_run_context,
+                               args=(*args,),
+                               kwargs={'runtime_overrides': [(MODULE_NAME, CHILD_CONN_CONFIG_KEY, child_conn)]})
+        p.start()
+        active_chats[chat_id] = parent_conn
+
     def error(bot: Bot, update: Update, error: TelegramError):
         """
         Log Errors caused by Updates.
         """
         logger.warning('Update "%s" caused error "%s"', update, error)
 
-    """Start the bot."""
-    # Create the EventHandler and pass it your bots token.
-    token = ctx.conf(key=TOKEN_CONFIG_KEY)
-    if not token:
-        logger.error('telegram-token is not set. Shutting down telegramio')
-        return Delete()
+    child_conn = ctx.conf(key=CHILD_CONN_CONFIG_KEY)
+    is_master_process = child_conn is None
+    if is_master_process:
+        # Master Process -> Start the bot
+        # Create the EventHandler and pass it your bots token.
+        token = ctx.conf(key=TOKEN_CONFIG_KEY)
+        if not token:
+            logger.error(f'{TOKEN_CONFIG_KEY} is not set. Shutting down telegramio')
+            return Delete()
+        child_config_paths_list = ctx.conf(key=CHILD_FILES_CONFIG_KEY)
+        if not ctx.conf(key=ALL_IN_ONE_CONTEXT_CONFIG_KEY) and (
+                not child_config_paths_list or not isinstance(child_config_paths_list, list)
+                or not all(os.path.isfile(child_config_path) for child_config_path in child_config_paths_list)):
+            logger.error(f'{CHILD_FILES_CONFIG_KEY} is not set (correctly). Shutting down telegramio')
+            return Delete()
 
-    updater: Updater = Updater(token)
-    # Get the dispatcher to register handlers
-    dp: Dispatcher = updater.dispatcher
-    # handle noncommand-messages with handle_input
-    dp.add_handler(MessageHandler(Filters.text, handle_text_input))
-    dp.add_handler(MessageHandler(Filters.photo, handle_photo))
-    # log all errors
-    dp.add_error_handler(error)
-    # Start the Bot
-    updater.start_polling()
+        updater: Updater = Updater(token)
+        # Get the dispatcher to register handlers
+        dp: Dispatcher = updater.dispatcher
+        if ctx.conf(key=ALL_IN_ONE_CONTEXT_CONFIG_KEY):
+            # handle noncommand-messages with the matching handler
+            dp.add_handler(MessageHandler(Filters.text, handle_text))
+            dp.add_handler(MessageHandler(Filters.photo, handle_photo))
+        else:
+            dp.add_handler(MessageHandler(Filters.text | Filters.photo, handle_input_multiprocess))
+        # log all errors
+        dp.add_error_handler(error)
+        # Start the Bot
+        updater.start_polling()  # non blocking
+
+        if not ctx.conf(key=ALL_IN_ONE_CONTEXT_CONFIG_KEY):
+            while not ctx.shutting_down():
+                # wait for children to write to Pipe and then send message to chat
+                tick_interval = 1. / ctx.conf(mod=Context.core_module_name, key=Context.tick_rate_config)
+                time.sleep(tick_interval)
+                for chat_id, parent_pipe in active_chats.items():
+                    if parent_pipe.poll():
+                        msg = parent_pipe.recv()
+                        if isinstance(msg, str):
+                            updater.bot.send_message(chat_id=chat_id, text=msg)
+                        else:
+                            logger.error(f'Tried sending non-str object as telegram message: {str(msg)}')
+
+    else:
+        # Child Process -> check pipe
+        try:
+            while not ctx.shutting_down():
+                # receive Bot,Update for telegram chat
+                bot, update = child_conn.recv()  # blocking
+                if update.effective_message.photo:
+                    handle_photo(bot, update)
+                elif update.effective_message.text:
+                    handle_text(bot, update)
+                else:
+                    logger.error(f"{MODULE_NAME} recieved an update it cannot handle.")
+        except EOFError:
+            # Pipe was closed -> Parent was killed
+            logger.info("Parent process was killed, therefore the telegram-child will shut down.")
+            ctx.shutdown()
 
 
 @state(read="rawio:out")
 def telegram_output(ctx: ContextWrapper):
     """
-    Sends the content of rawio:out to every currently active chat
+    If all telegram chats should be in the same context, sends the content of rawio:out to every currently active chat.
+    Otherwise it only sends output using the Pipe if it is a child process
     """
-    # TODO don't instantiate the updater every time
-    token = ctx.conf(key=TOKEN_CONFIG_KEY)
-    if not token:
-        logger.error('telegram-token is not set. Shutting down telegramio')
-        return Delete()
+    if ctx.conf(key=ALL_IN_ONE_CONTEXT_CONFIG_KEY):
+        # TODO don't instantiate the updater every time
+        token = ctx.conf(key=TOKEN_CONFIG_KEY)
+        if not token:
+            logger.error('telegram-token is not set. Shutting down telegramio')
+            return Delete()
 
-    updater: Updater = Updater(token)
-    for chat_id in active_chats:
-        updater.bot.send_message(chat_id=chat_id, text=ctx["rawio:out:changed"])
+        updater: Updater = Updater(token)
+        for chat_id in active_chats.keys():
+            updater.bot.send_message(chat_id=chat_id, text=ctx["rawio:out:changed"])
+    else:
+        child_conn = ctx.conf(key=CHILD_CONN_CONFIG_KEY)
+
+        if child_conn:
+            # Child Process -> write to Pipe
+            child_conn.send(ctx["rawio:out:changed"])
+        else:
+            # Master Process -> State not needed
+            return Delete

--- a/modules/ravestate_telegramio/telegram_bot.py
+++ b/modules/ravestate_telegramio/telegram_bot.py
@@ -224,7 +224,7 @@ def telegram_run(ctx: ContextWrapper):
                 elif update.effective_message.text:
                     handle_text(bot, update)
                 else:
-                    logger.error(f"{MODULE_NAME} recieved an update it cannot handle.")
+                    logger.error(f"{MODULE_NAME} received an update it cannot handle.")
         except EOFError:
             # Pipe was closed -> Parent was killed
             logger.info("Parent process was killed, therefore the telegram-child will shut down.")

--- a/test/modules/ravestate_telegramio/test_telegram_bot.py
+++ b/test/modules/ravestate_telegramio/test_telegram_bot.py
@@ -19,9 +19,7 @@ def test_telegram_run(context_wrapper_fixture: Context):
 
 
 def test_telegram_output(context_wrapper_fixture: ContextWrapper):
-    with LogCapture() as capture:
-        telegram_output(context_wrapper_fixture)
-        expected = 'telegram-token is not set. Shutting down telegramio'
-        capture.check_present((f"{FILE_NAME}", '\x1b[1;31mERROR\x1b[0m', f"{PREFIX} {expected}"))
-        # TODO: Write test for token present
+    # Master Process should return delete for telegram output
+    assert telegram_output(context_wrapper_fixture) == Delete
+    # TODO: Write test for token present
 


### PR DESCRIPTION
TelegramIO can now be run in separate contexts for each Chat! :speaking_head: 
There are two new Config Entries for TelegramIO:

- **child_config_files** (List): The config-paths listed here will be used as -f parameter for each new telegram chat. Currently only absolute paths are supported. :children_crossing: 
- **all_in_one_context** (boolean, default _False_): Switches between the old one-context behavior and the new multiprocess variant. :older_man: :older_woman: 

Technically there is also a third new config option for "child_conn", but this is not to be set in the configfile or via commandline. This is set by the master process when creating child processes to enable interprocess communication.

(Future) ToDo:
Currently there is a warning when creating a new child process because the "child_conn" config entry is overwritten with a Connection, but the type differs from the default value None. Is a way to specify types of config entries planned?
