### PR TITLE
Add example of user-defined signals and q/a states to documentation

### DIFF
--- a/docs/modules/ravestate_nlp/index.html
+++ b/docs/modules/ravestate_nlp/index.html
@@ -690,38 +690,6 @@ def postive_chicken(ctx: ContextWrapper):
         ctx[rawio.prop_out] = &quot;You said something about a chicken, i like chickens!&quot;
 </code></pre>
 
-<h3 id="using-user-defined-signals-and-questions-answering">Using User-defined Signals and Implementing Q/A-States</h3>
-<p>A user can define signals as needed and implement states reacting on them. If both a signal is emitted and something is written to <code class="python">rawio</code> in one state, the state needs to be defined with <code class="python">emit_detached=True</code>.</p>
-<h4 id="analyzing-a-sentence">React to User-defined States and Implement Q/A</h4>
-<p>Example: In one state a question is asks and then a user-defined signal is emitted that shows that the question has been stated. The other states reacts on the answer to this question.</p>
-<pre><code class="python">import ravestate as rs
-import ravestate_nlp as nlp
-import ravestate_rawio as rawio
-    
-chicken_signal = rs.Signal("chicken signal")
-    
-@rs.state(
-    cond=nlp.prop_tokens.changed()
-    write=rawio.prop_out,
-    signal=chicken_signal,
-    emit_detached=True
-)
-def ask_chicken_question(ctx: rs.ContextWrapper):
-    ctx[rawio.prop_out] = "Wanna know something awesome about chickens?"
-    return rs.Emit()
-    
-@rs.state(
-    cond=chicken_signal & nlp.prop_yesno.changed(),
-    read=nlp.prop_yesno,
-    write=rawio.prop_out
-)
-def answer_chicken_question(ctx: rs.ContextWrapper):
-    if ctx[nlp.prop_yesno] == "yes":
-        ctx[rawio.prop_out] = "Well, chicken's actually aren't that awesome."
-    elif ctx[nlp.prop_yesno] == "no":
-        ctx[rawio.prop_out] = "You're missing out on awesome chicken stories!"
-</code></pre>
-
 <h4 id="happy-language-processing-to-all-chickens-out-there">Happy language processing to all chickens out there!</h4>
                 
                   

--- a/docs/modules/ravestate_nlp/index.html
+++ b/docs/modules/ravestate_nlp/index.html
@@ -690,6 +690,38 @@ def postive_chicken(ctx: ContextWrapper):
         ctx[rawio.prop_out] = &quot;You said something about a chicken, i like chickens!&quot;
 </code></pre>
 
+<h3 id="using-user-defined-signals-and-questions-answering">Using User-defined Signals and Implementing Q/A-States</h3>
+<p>A user can define signals as needed and implement states reacting on them. If both a signal is emitted and something is written to <code class="python">rawio</code> in one state, the state needs to be defined with <code class="python">emit_detached=True</code>.</p>
+<h4 id="analyzing-a-sentence">React to User-defined States and Implement Q/A</h4>
+<p>Example: In one state a question is asks and then a user-defined signal is emitted that shows that the question has been stated. The other states reacts on the answer to this question.</p>
+<pre><code class="python">import ravestate as rs
+import ravestate_nlp as nlp
+import ravestate_rawio as rawio
+    
+chicken_signal = rs.Signal("chicken signal")
+    
+@rs.state(
+    cond=nlp.prop_tokens.changed()
+    write=rawio.prop_out,
+    signal=chicken_signal,
+    emit_detached=True
+)
+def ask_chicken_question(ctx: rs.ContextWrapper):
+    ctx[rawio.prop_out] = "Wanna know something awesome about chickens?"
+    return rs.Emit()
+    
+@rs.state(
+    cond=chicken_signal & nlp.prop_yesno.changed(),
+    read=nlp.prop_yesno,
+    write=rawio.prop_out
+)
+def answer_chicken_question(ctx: rs.ContextWrapper):
+    if ctx[nlp.prop_yesno] == "yes":
+        ctx[rawio.prop_out] = "Well, chicken's actually aren't that awesome."
+    elif ctx[nlp.prop_yesno] == "no":
+        ctx[rawio.prop_out] = "You're missing out on awesome chicken stories!"
+</code></pre>
+
 <h4 id="happy-language-processing-to-all-chickens-out-there">Happy language processing to all chickens out there!</h4>
                 
                   

--- a/modules/ravestate_nlp/README.md
+++ b/modules/ravestate_nlp/README.md
@@ -102,4 +102,40 @@ def postive_chicken(ctx: ContextWrapper):
         ctx[rawio.prop_out] = "You said something about a chicken, i like chickens!"
 ```
 
+### Using User-defined Signals and Implementing Q/A-States
+A user can define signals as needed and implement states reacting on them. 
+If both a signal is emitted and something is written to `rawio` in one state, the state needs to be defined with `emit_detached=True`.
+
+#### React to User-defined States and Implement Q/A
+Example: In one state a question is asks and then a user-defined signal is emitted that shows that the question has been stated. The other states reacts on the answer to this question.
+```python
+import ravestate as rs
+import ravestate_nlp as nlp
+import ravestate_rawio as rawio
+    
+chicken_signal = rs.Signal("chicken signal")
+    
+@rs.state(
+    cond=nlp.prop_tokens.changed(),
+    write=rawio.prop_out,
+    signal=chicken_signal,
+    emit_detached=True
+)
+def ask_chicken_question(ctx: rs.ContextWrapper):
+    ctx[rawio.prop_out] = "Wanna know something awesome about chickens?"
+    return rs.Emit()
+    
+@rs.state(
+    cond=chicken_signal & nlp.prop_yesno.changed(),
+    read=nlp.prop_yesno,
+    write=rawio.prop_out
+)
+def answer_chicken_question(ctx: rs.ContextWrapper):
+    if ctx[nlp.prop_yesno] == "yes":
+        ctx[rawio.prop_out] = "Well, chicken's actually aren't that awesome."
+    elif ctx[nlp.prop_yesno] == "no":
+        ctx[rawio.prop_out] = "You're missing out on awesome chicken stories!"
+```
+
+
 #### Happy language processing to all chickens out there!


### PR DESCRIPTION
During the work on [raveskills](https://github.com/Roboy/raveskills) we noticed that it might be helpful to have more detailed examples in the documentation. Therefore, I added an example that would have helped me a lot in the beginning. Maybe it would be nice to include?