### PR TITLE
ROS1 in Ravestate

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,8 @@ External (Red) and Skills (Green):
   | ravestate_idle       | Provides `bored` and `impatient` signals, as specified [here](https://github.com/Roboy/ravestate/issues/12).
   | ravestate_verbaliser | Utilities for easy management of conversational text, documented [here](modules/ravestate_verbaliser/README.md).
   | ravestate_nlp        | Spacy-based NLP properties and signals, documented [here](modules/ravestate_nlp/README.md).
-  | ravestate_ros2       | Provides specific `Ros2PubProperty`, `Ros2SubProperty` and `Ros2CallProperty` context props., which greatly simplify working with ROS2 in ravestate.
+  | ravestate_ros1       | Provides specific `Ros1PubProperty`, `Ros1SubProperty` and `Ros1CallProperty` context properties, which greatly simplify working with ROS1 in ravestate. Documentation [here](modules/ravestate_ros1/README.md).
+  | ravestate_ros2       | Provides specific `Ros2PubProperty`, `Ros2SubProperty` and `Ros2CallProperty` context properties, which greatly simplify working with ROS2 in ravestate.
 
 
 #### IO Modules

--- a/modules/ravestate_ros1/README.md
+++ b/modules/ravestate_ros1/README.md
@@ -1,0 +1,131 @@
+```
+  _____     ____     _____   __ 
+ |  __ \   / __ \   / ____| /_ |
+ | |__) | | |  | | | (___    | |
+ |  _  /  | |  | |  \___ \   | |
+ | | \ \  | |__| |  ____) |  | |
+ |_|  \_\  \____/  |_____/   |_|                                                              
+
+```
+
+## ROS1
+
+The ROS1 module enables easy integration of Publishers, Subscribers and Service Calls into Ravestate.
+It provides 3 Subclasses of property: Ros1SubProperty, Ros1PubProperty and Ros1CallProperty
+
+
+### Using the Properties
+
+#### Ros1SubProperty
+Subclass of property that is synchronized with a given ROS1-Topic.  
+Whenever it receives a new message from the topic, 
+the value is written to the property and a changed-Signal is emitted.
+
+Example: Property that subscribes to the ROS topic *chatter* of type *std_msgs/String* 
+and state that reacts upon new messages
+
+```python
+import ravestate as rs
+import ravestate_rawio as rawio
+from ravestate_ros1 import Ros1SubProperty
+
+from std_msgs.msg import String  # Import ROS message type
+
+with rs.Module(name="ros_chatter"):
+
+    prop_subscriber = Ros1SubProperty(name="subscriber", topic='chatter', msg_type=String)
+
+    @rs.state(read=prop_subscriber, write=rawio.prop_out)
+    def react_to_message(ctx: rs.ContextWrapper):
+        message = ctx[prop_subscriber.changed()]  # message is of type std_msgs.msg.String
+        ctx[rawio.prop_out] = f"Received on ROS-topic chatter: {message.data}"
+
+```
+
+#### Ros1PubProperty
+Subclass of property that publishes all values written to it to a given ROS1-Topic.
+
+Example: Property that publishes to the ROS topic *chatter* of type *std_msgs/String* 
+and state that writes all outputs of the dialog system to the property
+
+```python
+import ravestate as rs
+import ravestate_rawio as rawio
+from ravestate_ros1 import Ros1PubProperty
+
+from std_msgs.msg import String  # Import ROS message type
+
+with rs.Module(name="ros_chatter"):
+
+    prop_publisher = Ros1PubProperty(name="publisher", topic='chatter', msg_type=String)
+
+    @rs.state(read=rawio.prop_out, write=prop_publisher)
+    def ros_output(ctx: rs.ContextWrapper):
+        # create message of type std_msgs.msg.String
+        message = String(data=ctx[rawio.prop_out.changed()])
+        ctx[prop_publisher] = message
+
+```
+
+#### Ros1CallProperty
+Subclass of property that calls a ROS-Service when a value is written to it, 
+blocks until it gets the response, writes back the response into the property and returns.
+
+1. Build Request, can be of different form (see example):
+    - Parameters as a dict
+    - Parameters as ordered sequence
+    - Matching Request-Type
+2. Write Request to property, this blocks until a response is received and written back into the property.  
+If no response is received (timeout is 10 seconds per default, can be set with call_timeout),
+None is written back into the property.
+3. Now the response can be read from the property. Check if it is None because service was unavailable!
+
+Example: Property connected to the ROS service */add_two_ints* of type *rospy_tutorials/AddTwoInts* 
+and state that calls the Service through the property when the input is "add"
+
+```python
+import ravestate as rs
+import ravestate_rawio as rawio
+from ravestate_ros1 import Ros1CallProperty
+
+# Import ROS service type
+from rospy_tutorials.srv import AddTwoInts, AddTwoIntsRequest
+
+
+with rs.Module(name="add_two_ints"):
+
+    prop_addtwoints = Ros1CallProperty(name="addtwoints", 
+                                       service_name="/add_two_ints",
+                                       service_type=AddTwoInts,
+                                       call_timeout=5.0)
+
+    # prop_addtwoints has to be in read and write
+    @rs.state(cond=rawio.prop_in.changed(),
+              read=(rawio.prop_in, prop_addtwoints),
+              write=(rawio.prop_out, prop_addtwoints))
+    def add_two_ints(ctx):
+        if ctx[rawio.prop_in.changed()] == "add":
+            # 1. Build Request
+            # Option 1: Parameters as dict
+            request = {'a': 11, 'b': 232}
+            # Option 2: Parameters as ordered sequence
+            request = (1, 2)
+            # Option 3: Matching Request-Type
+            request = AddTwoIntsRequest(1, 2)
+            
+            # 2. Write Request to property. 
+            # This blocks until Response is written into property or service call timed out.
+            ctx[prop_addtwoints] = request
+            
+            # 3. Read Response (of type rospy_tutorials.srv.AddTwoIntsResponse) from property
+            response = ctx[prop_addtwoints]
+            
+            # Check if response is None
+            if response:
+                ctx[rawio.prop_out] = response.sum
+
+```
+
+
+
+#### Happy ROS-Ravestate Integration

--- a/modules/ravestate_ros1/__init__.py
+++ b/modules/ravestate_ros1/__init__.py
@@ -1,0 +1,14 @@
+import ravestate as rs
+
+from ravestate_ros1.ros1_properties import sync_ros_properties, Ros1SubProperty, Ros1PubProperty, Ros1CallProperty
+
+CONFIG = {
+    # name of the ROS-Node that is created by ravestate_ros1
+    ros1_properties.NODE_NAME_CONFIG_KEY: "ravestate_ros1",
+    # frequency for spinning of ROS-Node in spins per second (0: as fast as possible)
+    ros1_properties.SPIN_FREQUENCY_CONFIG_KEY: 10
+}
+
+with rs.Module(name="ros1", config=CONFIG) as mod:
+
+    mod.add(sync_ros_properties)

--- a/modules/ravestate_ros1/ros1_properties.py
+++ b/modules/ravestate_ros1/ros1_properties.py
@@ -1,0 +1,283 @@
+from typing import Dict
+
+import ravestate as rs
+
+from reggol import get_logger
+logger = get_logger(__name__)
+
+
+ROS1_AVAILABLE = True
+try:
+    import rospy
+except ImportError:
+    logger.error("Could not import rospy. Please make sure to have ROS1 installed.")
+    ROS1_AVAILABLE = False
+
+NODE_NAME_CONFIG_KEY = "ros1-node-name"
+SPIN_FREQUENCY_CONFIG_KEY = "ros1-spin-frequency"
+
+global_prop_set = set()
+global_node = None
+
+
+@rs.state(cond=rs.sig_startup)
+def sync_ros_properties(ctx: rs.ContextWrapper):
+    """
+    State that creates a ROS1-Node, registers all Ros1SubProperties and Ros1PubProperties in ROS1 and keeps them synced
+    """
+    global global_prop_set, global_node
+
+    # check for ROS1 availability
+    if not ROS1_AVAILABLE:
+        logger.error("ROS1 is not available, therefore all ROS1-Properties "
+                     "will be just normal properties without connection to ROS1!")
+        return rs.Delete()
+
+    # get config stuff
+    node_name = ctx.conf(key=NODE_NAME_CONFIG_KEY)
+    if not node_name:
+        logger.error(f"{NODE_NAME_CONFIG_KEY} is not set. Shutting down ravestate_ros1")
+        return rs.Delete()
+    spin_frequency = ctx.conf(key=SPIN_FREQUENCY_CONFIG_KEY)
+    if spin_frequency is None or spin_frequency < 0:
+        logger.error(f"{SPIN_FREQUENCY_CONFIG_KEY} is not set or less than 0. Shutting down ravestate_ros1")
+        return rs.Delete()
+    if spin_frequency == 0:
+        spin_sleep_time = 0
+    else:
+        spin_sleep_time = 1 / spin_frequency
+
+    # init ROS1
+    rospy.init_node(node_name, disable_signals=True)
+    global global_prop_set
+    # current_props: hash -> Subscriber/Publisher/ServiceProxy
+    current_props: Dict = dict()
+
+    # ROS1-Context Sync Loop
+    while not ctx.shutting_down() and not rospy.core.is_shutdown():
+        # remove deleted props
+        removed_props = current_props.keys() - global_prop_set
+        for prop_hash in removed_props:
+            item = current_props[prop_hash]
+            if isinstance(item, rospy.Subscriber):
+                item.subscriber.unregister()
+            elif isinstance(item, rospy.Publisher):
+                item.publisher.unregister()
+            current_props.pop(prop_hash)
+
+        # add new props
+        new_props = global_prop_set - current_props.keys()
+        for prop in new_props:
+            # register subscribers in ROS1
+            if isinstance(prop, Ros1SubProperty):
+                # register in context
+                @rs.receptor(ctx_wrap=ctx, write=prop.id())
+                def ros_to_ctx_callback(ctx, msg, prop_name: str):
+                    ctx[prop_name] = msg
+
+                prop.ros_to_ctx_callback = ros_to_ctx_callback
+                prop.subscriber = rospy.Subscriber(prop.topic, prop.msg_type, prop.ros_subscription_callback)
+                current_props[prop.__hash__()] = prop.subscriber
+            # register publishers in ROS1
+            if isinstance(prop, Ros1PubProperty):
+                prop.publisher = rospy.Publisher(prop.topic, prop.msg_type, queue_size=prop.queue_size)
+                current_props[prop.__hash__()] = prop.publisher
+            # register clients in ROS1
+            if isinstance(prop, Ros1CallProperty):
+                prop.client = rospy.ServiceProxy(prop.service_name, prop.service_type)
+                current_props[prop.__hash__()] = prop.client
+
+            # replace prop with hash in global_props
+            global_prop_set.remove(prop)
+            global_prop_set.add(prop.__hash__())
+
+        rospy.rostime.wallsleep(spin_sleep_time)
+
+    rospy.signal_shutdown("ravestate_ros1 is shutting down")
+
+
+class Ros1SubProperty(rs.Property):
+    def __init__(self, name: str, topic: str, msg_type, default_value=None, always_signal_changed: bool = True):
+        """
+        Initialize Property
+
+        * `name`: Name of the property
+
+        * `topic`: ROS1-Topic that should be subscribed
+
+        * `msg_type`: ROS1-Message type of messages in the topic
+
+        * `default_value`: Default value of the property
+
+        * `always_signal_changed`: if signal:changed should be emitted if value is written again without changing
+        """
+        super().__init__(
+            name=name,
+            allow_read=True,
+            allow_write=True,
+            allow_push=False,
+            allow_pop=False,
+            default_value=default_value,
+            always_signal_changed=always_signal_changed)
+        self.topic = topic
+        self.msg_type = msg_type
+        self.subscriber = None
+        self.ros_to_ctx_callback = None
+        global global_prop_set
+        global_prop_set.add(self)
+
+    def __del__(self):
+        global global_prop_set
+        global_prop_set.remove(self.__hash__())
+
+    def clone(self):
+        result = Ros1SubProperty(
+            name=self.name,
+            topic=self.topic,
+            msg_type=self.msg_type,
+            default_value=self.value,
+            always_signal_changed=self.always_signal_changed)
+        result.set_parent_path(self.parent_path)
+        return result
+
+    def ros_subscription_callback(self, msg):
+        """
+        Writes the message from ROS1 to the property
+
+        * `msg`: ROS1-Message that should be written into the property
+        """
+        if self.ros_to_ctx_callback:
+            logger.debug(f"{self.id()} received message {str(msg)} from topic {self.topic}")
+            self.ros_to_ctx_callback(msg=msg, prop_name=self.id())
+
+
+class Ros1PubProperty(rs.Property):
+    def __init__(self, name: str, topic: str, msg_type, queue_size: int = 10):
+        """
+        Initialize Property
+
+        * `name`: Name of the property
+
+        * `topic`: ROS1-Topic that messages should be pubished to
+
+        * `msg_type`: ROS1-Message type of messages in the topic
+
+        * `queue_size`: Limits the amount of queued messages if any ROS1-Subscriber is not receiving them fast enough
+        """
+        super().__init__(
+            name=name,
+            allow_read=True,
+            allow_write=True,
+            allow_push=False,
+            allow_pop=False,
+            default_value=None,
+            always_signal_changed=True)
+        self.topic = topic
+        self.msg_type = msg_type
+        self.queue_size = queue_size
+        self.publisher = None
+        global global_prop_set
+        global_prop_set.add(self)
+
+    def __del__(self):
+        global global_prop_set
+        global_prop_set.remove(self.__hash__())
+
+    def clone(self):
+        result = Ros1PubProperty(
+            name=self.name,
+            topic=self.topic,
+            msg_type=self.msg_type)
+        result.set_parent_path(self.parent_path)
+        return result
+
+    def write(self, value):
+        """
+        Publish value on ROS1
+
+        * `value`: ROS1-Message that should be published
+        """
+        if super().write(value):
+            if self.publisher:
+                logger.debug(f"{self.id()} is publishing message {str(value)} on topic {self.topic}")
+                self.publisher.publish(value)
+            elif ROS1_AVAILABLE:
+                logger.error(f"Message {str(value)} on topic {self.topic} "
+                             f"cannot be published because publisher was not registered in ROS1")
+
+
+class Ros1CallProperty(rs.Property):
+    def __init__(self, name: str, service_name: str, service_type, call_timeout: float = 10.0):
+        """
+        Initialize Property
+
+        * `name`: Name of the property
+
+        * `service_name`: ROS1-Service that should be called
+
+        * `service_type`: Type of the service used
+
+        * `call_timeout`: Timeout when waiting for availability of a service in seconds
+        """
+        super().__init__(
+            name=name,
+            allow_read=True,
+            allow_write=True,
+            allow_push=False,
+            allow_pop=False,
+            default_value=None,
+            always_signal_changed=False)
+        self.service_name = service_name
+        self.service_type = service_type
+        self.call_timeout = call_timeout
+        self.client = None
+        global global_prop_set
+        global_prop_set.add(self)
+
+    def __del__(self):
+        global global_prop_set
+        global_prop_set.remove(self.__hash__())
+
+    def clone(self):
+        result = Ros1CallProperty(
+            name=self.name,
+            service_name=self.service_name,
+            service_type=self.service_type,
+            call_timeout=self.call_timeout)
+        result.set_parent_path(self.parent_path)
+        return result
+
+    def write(self, value):
+        """
+        Call Service and receive result directly in the property.
+        Blocks during service-call.
+        If service is not available, writes None into the property value and returns.
+
+        * `value`: Either Request-Object for the service or dict containing the attributes of the Request
+        """
+        if super().write(value):
+            if self.client:
+                try:
+                    rospy.wait_for_service(self.service_name, timeout=self.call_timeout)
+                except rospy.ROSException:
+                    logger.error(f'service {self.service_name} not available')
+                    super().write(None)
+                    return
+
+                logger.debug(f"{self.id()} is sending request {str(value)} to service {self.service_name}")
+                if isinstance(value, dict):
+                    # value is dict {"param1": value1, "param2": value2}
+                    result = self.client.call(**value)
+                elif isinstance(value, tuple) or isinstance(value, list):
+                    # value is ordered sequence (value1, value2)
+                    result = self.client.call(*value)
+                else:
+                    # value should be of matching Request-Type
+                    result = self.client.call(value)
+
+                super().write(result)
+
+            elif ROS1_AVAILABLE:
+                logger.error(f"Request {str(value)} to service {self.service_name} "
+                             f"cannot be sent because client was not registered in ROS1")
+

--- a/modules/ravestate_telegramio/telegram_bot.py
+++ b/modules/ravestate_telegramio/telegram_bot.py
@@ -182,7 +182,7 @@ def telegram_run(ctx: rs.ContextWrapper):
         """
         Log Errors caused by Updates.
         """
-        logger.warning('Update "%s" caused error "%s"', update, error)
+        logger.warning(f'Update {update.effective_message} caused error {error.message}')
 
     def _manage_children(updater):
         """


### PR DESCRIPTION
Fixes #116
The same interface between properties and ROS we have in ravestate_ros2, only this time with ROS1 :older_man: 
What's left to do:
- [x] Documentation in a Readme with examples :newspaper_roll: 
- [x] Tests of course, but maybe this is for another PR. Maybe we can do tests that run inside our beloved docker container that has ROS and ROS2? :package: 