### PR TITLE
Graph Horizontal Scrolling

### DIFF
--- a/modules/raveboard/src/app/app.component.scss
+++ b/modules/raveboard/src/app/app.component.scss
@@ -6,9 +6,9 @@ $header-height: 50px;
   overflow: hidden;
 
   display: grid;
-  grid-template-columns: 3fr minmax(250px, 1fr) minmax(250px, 1fr);
+  grid-template-columns: 3fr minmax(250px, 1fr);
   grid-template-rows: $header-height 1fr;
-  grid-template-areas: "header header header" "main main side";
+  grid-template-areas: "header header" "main side";
 }
 
 .header {

--- a/modules/raveboard/src/app/app.component.ts
+++ b/modules/raveboard/src/app/app.component.ts
@@ -10,23 +10,18 @@ import { Component } from '@angular/core';
             <div class="main">
                 <app-activation-spike-graph class="graph-area"></app-activation-spike-graph>
             </div>
-            <div class="side">
-                <app-mock-data-controller></app-mock-data-controller>
-                <br>
-                <div>
-                    TODOs:
-                    <ul>
-                        <li>allow to move graph with drag</li>
-                        <li>idea: allow to move columns up and down (to a certain degree)</li>
-                    </ul>
-                </div>
+            <div class="side">                
+                <app-chat-window [style.display]="debugMode ? 'none' : null"></app-chat-window>                
+                <app-mock-data-controller [style.display]="debugMode ? null : 'none'"></app-mock-data-controller>                
             </div> 
-            <div class="side2">
-                <app-chat-window></app-chat-window>
+            <!-- debug button, can be enabled with dev tools -->
+            <div style="position: fixed; top: 5px; right: 5px; display: none">
+                <button (click)="debugMode = !debugMode">Debug</button>
             </div>
         </div>
     `,
     styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
+    debugMode = false;
 }

--- a/modules/raveboard/src/app/app.component.ts
+++ b/modules/raveboard/src/app/app.component.ts
@@ -10,7 +10,6 @@ import { Component } from '@angular/core';
             <div class="main">
                 <app-activation-spike-graph class="graph-area"></app-activation-spike-graph>
             </div>
-            <!-- Uncomment when mock data panel is required.
             <div class="side">
                 <app-mock-data-controller></app-mock-data-controller>
                 <br>
@@ -21,8 +20,8 @@ import { Component } from '@angular/core';
                         <li>idea: allow to move columns up and down (to a certain degree)</li>
                     </ul>
                 </div>
-            </div> -->
-            <div class="side">
+            </div> 
+            <div class="side2">
                 <app-chat-window></app-chat-window>
             </div>
         </div>

--- a/modules/raveboard/src/app/model/mocks/mock-data-controller.component.ts
+++ b/modules/raveboard/src/app/model/mocks/mock-data-controller.component.ts
@@ -17,7 +17,7 @@ import { MOCK_MESSAGES } from "./mock-messages";
         <h3>Mock messages</h3>
         <button (click)="chatSend()">Chat Send</button>
         <button (click)="chatReceive()">Chat Receive</button>
-        <h3>Last mock message</h3>
+        <h3>Last mock data / message</h3>
         <div class="data-json">
             <pre>{{lastMockMessage ? (lastMockMessage | json) : '- none -'}}</pre>
         </div>
@@ -86,13 +86,15 @@ export class MockDataControllerComponent {
     }
 
     chatSend() {
-        this.ioService.sendMessage(this.randomMessage())
+        this.lastMockMessage = this.randomMessage();
+        this.ioService.sendMessage(this.lastMockMessage)
     }
 
     chatReceive() {
+        this.lastMockMessage = this.randomMessage();
         this.ioService.messagesToUI.next({
             type: 'output',
-            text: this.randomMessage()
+            text: this.lastMockMessage
         })
     }
 
@@ -103,6 +105,6 @@ export class MockDataControllerComponent {
         for (let i = 0; i < n; i++) {
             msg += words[Math.floor(Math.random() * words.length)] + ' ';
         }
-        return msg;
+        return msg.trim();
     }
 }

--- a/modules/raveboard/src/app/svg/activation-spike-graph/activation-spike-graph.component.scss
+++ b/modules/raveboard/src/app/svg/activation-spike-graph/activation-spike-graph.component.scss
@@ -5,8 +5,11 @@
 }
 
 svg {
-  width: 100%;
-  height: 100%
+  width: 1px;
+  height: 100%;
+  overflow: visible;
+  position: absolute;
+  right: 0;
 }
 
 .moving-container {
@@ -15,11 +18,11 @@ svg {
 
 .controls {
   position: absolute;
-  bottom: 0;
-  right: 5px;
+  top: 5px;
+  left: 0;
   padding: 10px;
   background: #222;
-  border-radius: 30px 0 0 0;
+  border-radius: 0 0 30px 0;
 }
 
 .percentage-label {

--- a/modules/raveboard/src/app/svg/activation-spike-graph/activation-spike-graph.component.scss
+++ b/modules/raveboard/src/app/svg/activation-spike-graph/activation-spike-graph.component.scss
@@ -6,14 +6,10 @@
 
 svg {
   width: 1px;
-  height: 100%;
+  height: 1px;
+  top: 50%;
   overflow: visible;
-  position: absolute;
-  right: 0;
-}
-
-.moving-container {
-  transition: transform 0.5s;
+  position: relative;
 }
 
 .controls {
@@ -29,7 +25,7 @@ svg {
   font-size: 12px;
   width: 50px;
   display: inline-block;
-  text-align: right;
+  text-align: center;
   padding: 0 10px;
 }
 

--- a/modules/raveboard/src/app/svg/activation-spike-graph/activation-spike-graph.component.scss
+++ b/modules/raveboard/src/app/svg/activation-spike-graph/activation-spike-graph.component.scss
@@ -19,6 +19,7 @@ svg {
   padding: 10px;
   background: #222;
   border-radius: 0 0 30px 0;
+  user-select: none;
 }
 
 .percentage-label {

--- a/modules/raveboard/src/app/svg/activation-spike-graph/activation-spike-graph.component.ts
+++ b/modules/raveboard/src/app/svg/activation-spike-graph/activation-spike-graph.component.ts
@@ -79,7 +79,7 @@ export class NodeData {
             <button (click)="scaleDown()" class="round">-</button>
             <span class="percentage-label">{{(scale * 100).toFixed(0)}}%</span>
             <button (click)="scaleUp()" class="round">+</button>
-            <button (click)="scale = 1" [disabled]="scale == 1">100%</button>
+            <button (click)="resetScale()" [disabled]="scale == 1">100%</button>
             <span class="separator">|</span>
             <button (click)="clear()">Clear Graph</button>
         </div>
@@ -235,25 +235,30 @@ export class ActivationSpikeGraphComponent implements OnDestroy {
 
     scaleUp() {
         if (this.scale < 4) {
-            this.scale *= 1.1;
-            const e = this.wrapper.nativeElement;
-            const dx = (e.scrollLeft + e.clientWidth / 2) * 0.1;
-            setTimeout(() => {
-                e.scrollLeft += dx;
-            }, 0)
-
+            this.scaleBy(1.1);
         }
     }
 
     scaleDown() {
         if (this.scale >= 0.3) {
-            this.scale /= 1.1;
-            const e = this.wrapper.nativeElement;
-            const dx = (e.scrollLeft + e.clientWidth / 2) * (1 - 1 / 1.1);
-            setTimeout(() => {
-                e.scrollLeft -= dx;
-            }, 0)
+            this.scaleBy(1 / 1.1);
         }
+    }
+
+    resetScale() {
+
+        this.scaleBy(1 / this.scale);
+        this.scale = 1;
+
+    }
+
+    scaleBy(factor: number) {
+        this.scale *= factor;
+        const e = this.wrapper.nativeElement;
+        const dx = (e.scrollLeft + e.clientWidth / 2) * (factor - 1);
+        setTimeout(() => {
+            e.scrollLeft += dx;
+        }, 0)
     }
 
     getTransform() {

--- a/modules/raveboard/src/app/svg/activation-spike-graph/activation-spike-graph.component.ts
+++ b/modules/raveboard/src/app/svg/activation-spike-graph/activation-spike-graph.component.ts
@@ -246,18 +246,17 @@ export class ActivationSpikeGraphComponent implements OnDestroy {
     }
 
     resetScale() {
-
         this.scaleBy(1 / this.scale);
-        this.scale = 1;
-
     }
 
     scaleBy(factor: number) {
         this.scale *= factor;
+        this.svg.nativeElement.style.width = this.columns.length * this.nodeSpacingX * this.scale + 'px';
         const e = this.wrapper.nativeElement;
         const dx = (e.scrollLeft + e.clientWidth / 2) * (factor - 1);
+        const targetScroll = e.scrollLeft + dx;
         setTimeout(() => {
-            e.scrollLeft += dx;
+            e.scrollLeft = targetScroll;
         }, 0)
     }
 

--- a/modules/raveboard/src/app/svg/activation-spike-graph/activation-spike-graph.component.ts
+++ b/modules/raveboard/src/app/svg/activation-spike-graph/activation-spike-graph.component.ts
@@ -50,40 +50,40 @@ export class NodeData {
 @Component({
     selector: 'app-activation-spike-graph',
     template: `
-        <svg [attr.viewBox]="'0 0 1000 1'" preserveAspectRatio="xMidYMid meet">
-            <g class="moving-container" [style.transform]="getTransform()">
-
-                <!-- connectors for every node -->
-                <ng-container *ngFor="let node of allNodes.values()">
-                    <ng-container *ngIf="node.visible">
-                        <g connector *ngFor="let p of node.parents" [fromX]="p.x" [toX]="node.x" [fromY]="p.y"
-                           [toY]="node.y"
-                           [style.opacity]="hoveredNode && hoveredNode != node ? .1 : 1"></g>
-                    </ng-container>
-                </ng-container>
-
-                <!-- all nodes on top of connectors -->
-                <ng-container *ngFor="let node of allNodes.values()">
-                    <g node *ngIf="node.visible"
-                       (mouseenter)="hoverStart(node)" (mouseleave)="hoverEnd()"
-                       [x]="node.x" [y]="node.y" [label]="node.label"
-                       [nodeType]="node.nodeType" [nodeStatus]="node.element.status"
-                       [style.opacity]="node.transparent ? .2 : 1"></g>
-                </ng-container>
-
-            </g>
-        </svg>
+        <div style="overflow-x: scroll; width: 100%; height: 100%; scrollbar-width: thin">
+            <div style="height:100%" [style.width]="">
+                <svg [attr.viewBox]="'0 0 1 ' + ySize" preserveAspectRatio="xMidYMid meet">
+                    <g class="moving-container" [style.transform]="getTransform()">
+        
+                        <!-- connectors for every node -->
+                        <ng-container *ngFor="let node of allNodes.values()">
+                            <ng-container *ngIf="node.visible">
+                                <g connector *ngFor="let p of node.parents" [fromX]="p.x" [toX]="node.x" [fromY]="p.y"
+                                   [toY]="node.y"
+                                   [style.opacity]="hoveredNode && hoveredNode != node ? .1 : 1"></g>
+                            </ng-container>
+                        </ng-container>
+        
+                        <!-- all nodes on top of connectors -->
+                        <ng-container *ngFor="let node of allNodes.values()">
+                            <g node *ngIf="node.visible"
+                               (mouseenter)="hoverStart(node)" (mouseleave)="hoverEnd()"
+                               [x]="node.x" [y]="node.y" [label]="node.label"
+                               [nodeType]="node.nodeType" [nodeStatus]="node.element.status"
+                               [style.opacity]="node.transparent ? .2 : 1"></g>
+                        </ng-container>
+        
+                    </g>
+                </svg>
+            </div>
+        </div>
         <div class="controls">
+            <button (click)="clear()">Clear Graph</button>
+            <span class="separator">|</span>
             <span class="percentage-label">{{(scale * 100).toFixed(0)}}%</span>
             <button (click)="scaleDown()" class="round">-</button>
             <button (click)="scaleUp()" class="round">+</button>
             <button (click)="scale = 1" [disabled]="scale == 1">100%</button>
-            <span class="separator">|</span>
-            <button (click)="moveLeft()" class="round">&lt;</button>
-            <button (click)="resetOffset()" [disabled]="xOffset == 0">Reset Offset</button>
-            <button (click)="moveRight()" class="round">&gt;</button>
-            <span class="separator">|</span>
-            <button (click)="clear()">Clear Graph</button>
         </div>
     `,
     styleUrls: ['./activation-spike-graph.component.scss']
@@ -97,8 +97,8 @@ export class ActivationSpikeGraphComponent implements OnDestroy {
     ySpacing = 100;
     maxNodesPerColumn = 4;
 
+    ySize = 500;
     scale = 1;
-    xOffset = 0;
 
     allNodes: Map<number, NodeData> = new Map();
     columns: Array<Set<NodeData>> = [new Set()];
@@ -211,7 +211,7 @@ export class ActivationSpikeGraphComponent implements OnDestroy {
         }
 
         // reposition column
-        let y = -(visibleNodes - 1) / 2 * this.ySpacing;
+        let y = -(visibleNodes - 1) / 2 * this.ySpacing + this.ySize / 2;
         for (const node of this.columns[targetColumnID].values()) {
             if (!node.visible) {
                 continue;
@@ -244,21 +244,10 @@ export class ActivationSpikeGraphComponent implements OnDestroy {
         }
     }
 
-    moveLeft() {
-        this.xOffset -= 300 / this.scale;
-    }
-
-    moveRight() {
-        this.xOffset += 300 / this.scale;
-    }
-
-    resetOffset() {
-        this.xOffset = 0;
-    }
-
     getTransform() {
-        const containerPosX = 800 - this.columns.length * this.nodeSpacingX - this.xOffset;
-        const transform = `translateX(900px) scale(${this.scale.toFixed(2)}) translateX(-900px) translateX(${containerPosX}px)`;
+        const containerPosX = - this.columns.length * this.nodeSpacingX;
+        const hy = this.ySize / 2;
+        const transform = `translateY(${hy}px) scale(${this.scale.toFixed(2)}) translateY(-${hy}px) translateX(${containerPosX}px)`;
         return this.sanitizer.bypassSecurityTrustStyle(transform);
     }
 
@@ -280,6 +269,11 @@ export class ActivationSpikeGraphComponent implements OnDestroy {
             node.transparent = false;
         }
         this.hoveredNode = null;
+    }
+
+    graphWidth() {
+
+        return this.sanitizer.bypassSecurityTrustStyle(`calc(100% + ${Math.round(this.columns.length * this.nodeSpacingX)}px)`);
     }
 
 }

--- a/modules/raveboard/src/app/svg/activation-spike-graph/activation-spike-graph.component.ts
+++ b/modules/raveboard/src/app/svg/activation-spike-graph/activation-spike-graph.component.ts
@@ -92,8 +92,8 @@ export class ActivationSpikeGraphComponent implements OnDestroy {
 
     // distance between two nodes (x-axis)
     nodeSpacingX = 180;
-    ySpacing = 100;
-    maxNodesPerColumn = 4;
+    nodeSpacingY = 100;
+    maxNodesPerColumn = 5;
 
     scale = 1;
 
@@ -125,7 +125,7 @@ export class ActivationSpikeGraphComponent implements OnDestroy {
                     node.parents.push(parent);
                 }
             }
-            const lastColumnFull = this.columns[this.columns.length - 1].size > this.maxNodesPerColumn;
+            const lastColumnFull = this.columns[this.columns.length - 1].size >= this.maxNodesPerColumn;
 
             // create new column if necessary
             if (parentInLastCol || lastColumnFull) {
@@ -186,7 +186,7 @@ export class ActivationSpikeGraphComponent implements OnDestroy {
 
                 // need to insert new into last column
                 if (highestParentColumn >= this.columns.length - 1
-                    || this.columns[this.columns.length - 1].size > this.maxNodesPerColumn) {
+                    || this.columns[this.columns.length - 1].size >= this.maxNodesPerColumn) {
                     // last column not ok (full or has parents)
                     this.columns.push(new Set());
                     this.scheduleScrollSnapCheck();
@@ -212,14 +212,14 @@ export class ActivationSpikeGraphComponent implements OnDestroy {
         }
 
         // reposition column
-        let y = -(visibleNodes - 1) / 2 * this.ySpacing;
+        let y = -(visibleNodes - 1) / 2 * this.nodeSpacingY;
         for (const node of this.columns[targetColumnID].values()) {
             if (!node.visible) {
                 continue;
             }
             node.x = targetColumnID * this.nodeSpacingX + 85;
             node.y = y;
-            y += this.ySpacing;
+            y += this.nodeSpacingY;
         }
 
     }


### PR DESCRIPTION
This PR adds a native horizontal scrolling to the graph.

You need to hold Shift if you are scrolling with the mouse wheel (default browser behavior).
Scrolling is probably better on touch devices / trackpads.

I had to remove some CSS transitions due to conflicts with scrolling: scaling and adding new nodes is not animated anymore. This is fine since scaling is used not too often and animated insertion did move the complete graph, even if you didn't want it. Also, the SVG viewbox is gone. The graph won't resize automatically and you have full manual control over scale. Bigger screen is better. 

The mock data panel can now be enabled for debugging. You can use the browser dev tools to show the debug button which toggles between chat and debug panel. 